### PR TITLE
Fix segfault if ioperm fails

### DIFF
--- a/dell-bios-fan-control.c
+++ b/dell-bios-fan-control.c
@@ -36,12 +36,12 @@
 #define DISABLE_BIOS_METHOD2 0x34a3
 #define ENABLE_BIOS_METHOD2  0x35a3
 
-int init_ioperm(void)
+void init_ioperm(void)
 {
-    if (ioperm(0xb2, 4, 1))
-        perror("ioperm:");
-    if (ioperm(0x84, 4, 1))
-        perror("ioperm:");
+    if (ioperm(0xb2, 4, 1) || ioperm(0x84, 4, 1)) {
+	perror("ioperm");
+	exit(EXIT_FAILURE);
+    }
 }
 
 struct smm_regs {


### PR DESCRIPTION
If ioperm fails, the program should terminate.
Instead, it just ignores the error, causing a
segfault.
This issue was also fixed in dellfan.